### PR TITLE
docs: Add Sheet access policy and update Phase completion status

### DIFF
--- a/HANDOFF_SUMMARY.txt
+++ b/HANDOFF_SUMMARY.txt
@@ -253,7 +253,10 @@ AI Assistant: Claude (Anthropic) via Windsurf Cascade
 
 Google Sheet: 
   ID: 1cR5X2xFSGffivfsMjyHDDeDJQv6R0kQpVUJsEJ2_1yY
-  Link: https://docs.google.com/spreadsheets/d/1cR5X2xFSGffivfsMjyHDDeDJQv6R0kQpVUJsEJ2_1yY/edit
+  URL: https://docs.google.com/spreadsheets/d/1cR5X2xFSGffivfsMjyHDDeDJQv6R0kQpVUJsEJ2_1yY/edit
+  Owner: jschull@gmail.com
+  Access Policy: Write access granted to trusted users only
+  Note: Sheet URL not shared with end users (not ready for public editing)
 
 API Credentials (embedded in index.html):
   API Key: AIzaSyBp23GwrTURmM3Z1ERZocotnu3Tn96TmUo

--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ const API_KEY = 'AIzaSyBp23GwrTURmM3Z1ERZocotnu3Tn96TmUo';
 const CLIENT_ID = '57881875374-flipnf45tc25cq7emcr9qhvq7unk16n5.apps.googleusercontent.com';
 ```
 
-**Current OAuth Configuration:**
+**Google Sheet Configuration:**
+- **Sheet URL**: https://docs.google.com/spreadsheets/d/1cR5X2xFSGffivfsMjyHDDeDJQv6R0kQpVUJsEJ2_1yY/edit
+- **Sheet Owner**: jschull@gmail.com
+- **Access Policy**: Write access granted to trusted users only
+- **Note**: Sheet URL not shared with end users (not ready for public editing)
+
+**OAuth Configuration:**
 - **OAuth App Name**: ERA Graph Browser Client
 - **Google Cloud Account**: fathomizer@ecorestorationalliance.com
 - **Console**: https://console.cloud.google.com/apis/credentials?project=57881875374

--- a/VISION.md
+++ b/VISION.md
@@ -50,38 +50,43 @@ Create a **movement-wide utility** for collaborative network mapping where:
 
 ## Architecture Evolution
 
-### Phase 1: Static Viewer (Current - October 2025)
+### Phase 1: Static Viewer ✅ COMPLETED (October 2025)
 
 **Goal:** Get the viewer working without a server
 
 **Features:**
-- Pure HTML/JavaScript (no backend)
-- Loads from single global Google Sheet
-- View-only (or edit with sign-in)
-- Deployable to GitHub Pages
+- ✅ Pure HTML/JavaScript (no backend)
+- ✅ Loads from single global Google Sheet
+- ✅ Interactive graph visualization
+- ✅ Deployed to GitHub Pages
 
-**Status:** In progress (this project)
+**Status:** Complete and deployed
 
-**Timeline:** 2-4 hours (immediate next work session)
+**Completed:** October 15, 2025
+
+**URL:** https://jonschull.github.io/ERA_Landscape_Static/
 
 ---
 
-### Phase 2: OAuth Editing (Next - November 2025)
+### Phase 2: OAuth Editing ✅ COMPLETED (October 2025)
 
 **Goal:** Enable users to contribute to shared database
 
 **Features:**
-- "Sign In" button (Google OAuth)
-- Add/edit nodes and edges
-- Save changes back to global Sheet
-- Attribution (track who added what)
+- ✅ "Sign In" button (Google OAuth)
+- ✅ Add/edit nodes and edges
+- ✅ Save changes back to global Sheet
+- ✅ OAuth app published to production (anyone can sign in)
 
 **Technical:**
-- Google Identity Services (OAuth 2.0)
-- Sheets API write permission
-- User permission checking
+- ✅ Google Identity Services (OAuth 2.0)
+- ✅ Sheets API write permission
+- ✅ OAuth Client: ERA Graph Browser Client
+- ✅ Status: In production (public access enabled)
 
-**Timeline:** 4-6 hours (once Phase 1 deployed)
+**Completed:** October 19, 2025
+
+**Note:** Attribution tracking (created_by, updated_by) planned for Phase 3
 
 ---
 
@@ -349,18 +354,18 @@ Plus: private column (boolean: false = public/merged, true = private/excluded)
 
 ## Success Metrics
 
-### Phase 1 Success (Static Viewer)
+### Phase 1 Success (Static Viewer) ✅ ACHIEVED
 - ✅ Deploys to GitHub Pages
 - ✅ Loads data from Google Sheets
 - ✅ No console errors
 - ✅ Graph displays and works
 - ✅ 5+ users can access and view
 
-### Phase 2 Success (OAuth Editing)
-- ✅ Users can sign in
+### Phase 2 Success (OAuth Editing) ✅ ACHIEVED
+- ✅ Users can sign in (OAuth in production)
 - ✅ Users can add/edit nodes and edges
 - ✅ Changes save to global Sheet
-- ✅ 10+ users contributing data
+- ⏳ 10+ users contributing data (pending user adoption)
 
 ### Phase 3 Success (Personal Sheets)
 - ✅ Users have personal sheets


### PR DESCRIPTION
## Summary

Adds Google Sheet ownership information, access policy documentation, and updates VISION.md to reflect completion of Phase 1 and Phase 2.

## Changes

### 1. Google Sheet Documentation (README.md, HANDOFF_SUMMARY.txt)
- **Sheet URL**: Added direct link to Google Sheet
- **Owner**: jschull@gmail.com
- **Access Policy**: Write access granted to trusted users only
- **Privacy Note**: Sheet URL not shared with end users (Sheet not ready for public editing)

### 2. VISION.md Updates
- ✅ **Phase 1: Static Viewer** - Marked COMPLETED (October 15, 2025)
  - Deployed to GitHub Pages
  - Interactive graph visualization working
- ✅ **Phase 2: OAuth Editing** - Marked COMPLETED (October 19, 2025)  
  - OAuth app published to production
  - Anyone can sign in with Google account
  - Users can add/edit/save to global Sheet
- Updated success metrics to show both phases achieved

## Context

- OAuth was successfully published to production today
- Current policy: Trusted users get write access to Sheet
- Sheet URL kept private (not ready for user editing yet)
- Attribution tracking (created_by, updated_by) planned for next phase

## Testing

- [x] Documentation accurately reflects current state
- [x] All links valid and accessible